### PR TITLE
Initial Views and Fixtures

### DIFF
--- a/rockapi/fixtures/rocks.json
+++ b/rockapi/fixtures/rocks.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "rockapi.rock",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "type": 3,
+            "name": "Tiana",
+            "weight": 1.3
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 2,
+        "fields": {
+            "user": 1,
+            "type": 1,
+            "name": "Orpha",
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 3,
+        "fields": {
+            "user": 1,
+            "type": 5,
+            "name": "Sasha",
+            "weight": 0.29
+        }
+    }
+]

--- a/rockapi/fixtures/types.json
+++ b/rockapi/fixtures/types.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "rockapi.type",
+        "pk": 1,
+        "fields": {
+            "label": "Metamorphic"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 2,
+        "fields": {
+            "label": "Igneous"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 3,
+        "fields": {
+            "label": "Sedimentary"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 4,
+        "fields": {
+            "label": "Shale"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 5,
+        "fields": {
+            "label": "Basalt"
+        }
+    }
+]

--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import login_user, register_user
 from .type_view import TypeView
+from .rock_view import RockView

--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,1 +1,2 @@
 from .auth import login_user, register_user
+from .type_view import TypeView

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -1,0 +1,42 @@
+from django.http import HttpResponseServerError
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from rockapi.models import Rock
+
+class RockView(ViewSet):
+    """Rock view set"""
+
+    
+    def list(self, request):
+        """Handle GET requests for all items
+        
+        Returns:
+            Response -- JSON serialized array
+        """
+
+        try:
+            rocks = Rock.objects.all()
+            serialized = RockSerializer(rocks, many=True)
+            
+            return Response(serialized.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def create(self, request):
+        """Handle POST operations
+        
+        Returns:
+            Response -- JSON serialized instance
+        """
+
+        # You will implement this feature in a future chapter
+        return Response("", status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    class Meta:
+        model = Rock
+        fields = ( 'id', 'name', 'weight' )

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseServerError
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rockapi.models import Rock
+from rockapi.models import Rock, Type
 
 class RockView(ViewSet):
     """Rock view set"""
@@ -34,9 +34,19 @@ class RockView(ViewSet):
         return Response("", status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
-class RockSerializer(serializers.ModelSerializer):
+class RockTypeSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     class Meta:
+        model = Type
+        fields = ( 'label', )
+
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    type = RockTypeSerializer(many=False)
+    
+    class Meta:
         model = Rock
-        fields = ( 'id', 'name', 'weight' )
+        fields = ( 'id', 'name', 'weight', 'user', 'type' )

--- a/rockapi/views/type_view.py
+++ b/rockapi/views/type_view.py
@@ -1,0 +1,38 @@
+"""View module for handling requests for type data"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rockapi.models import Type
+
+class TypeView(ViewSet):
+    """Rock API types view"""
+
+    def list(self, request):
+        """Handle GET requests to all types
+        
+        Returns:
+            Response -- JSON serialized list of types
+        """
+
+        types = Type.objects.all()
+        serialized = TypeSerializer(types, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+    
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single type
+        
+        Returns:
+            Response -- JSON serialized type record
+        """
+
+        rock_type = Type.objects.get(pk=pk)
+        serialized = TypeSerializer(rock_type)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+
+
+class TypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for types"""
+    class Meta:
+        model = Type
+        fields = ('id', 'label')

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user
+from rockapi.views import register_user, login_user, TypeView
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'types', TypeView, 'type')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from rockapi.views import register_user, login_user, TypeView
+from rockapi.views import register_user, login_user, TypeView, RockView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'types', TypeView, 'type')
+router.register(r'rocks', RockView, 'rock')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
### Purpose
To allow Users to request Types and Rocks

### Files Changed
- Created file, and added initial seed data for Types in new `types.json`
- Created file, and added initial seed data for Rocks in new `rocks.json`
- Created View file, and wrote logic for Type Serializer, GET all endpoint, and GET single endpoint for Types in new `type_view.py` View
- Created View file, and wrote logic for Rock Serializer, Rock Type Serializer, GET all endpoint, and initial POST endpoint for Rocks in new `rock_view.py` View
- Imported TypeView and RockView in `__init__.py` package module in `/rockapi/views` directory
- Added route for Types and Rocks in `urls.py`

### To Test
Fetch, setup, create or recreate migration, and run debugger on project, then confirm the following
- GET request `/types` returns a list of all Types, including Id and Label
- GET request `/types/{id}` returns the appropriate Type, including Id and Label
- GET request `/rocks` returns a list of all Rocks, including Id, Name, Weight, User Id, and Type with embedded Label