### PR TITLE
Rock User Serialization

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -40,7 +40,7 @@ class RockTypeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Type
-        fields = ( 'label', )
+        fields = ( 'id', 'label', )
 
 
 class RockUserSerializer(serializers.ModelSerializer):

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -3,6 +3,7 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rockapi.models import Rock, Type
+from django.contrib.auth.models import User
 
 class RockView(ViewSet):
     """Rock view set"""
@@ -42,10 +43,28 @@ class RockTypeSerializer(serializers.ModelSerializer):
         fields = ( 'label', )
 
 
+class RockUserSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    firstName = serializers.SerializerMethodField()
+    lastName = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = User
+        fields = ( 'id', 'firstName', 'lastName', )
+    
+    def get_firstName(self, obj):
+        return obj.first_name
+
+    def get_lastName(self, obj):
+        return obj.last_name
+
+
 class RockSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     type = RockTypeSerializer(many=False)
+    user = RockUserSerializer(many=False)
     
     class Meta:
         model = Rock


### PR DESCRIPTION
### Purpose
To embed information on the User who added the Rock to the database when serializing a Rock

### Files Changed
- Added serialization for User assosciated with a Rock, and added Id field to Rock Type serializer in `rock_view.py`

### To Test
Fetch, setup, create or recreate database, then run, and confirm the following
- GET endpoint `/rocks` now embeds the Id, First Name, and Last Name of the User assosciated with each Rock, and the Id of the Rock's Type