### PR TITLE
Feature - Delete Rocks

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -54,8 +54,12 @@ class RockView(ViewSet):
         """
         try:
             rock = Rock.objects.get(pk=pk)
-            rock.delete()
-            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+            if rock.user == request.auth.user:
+                rock.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            
+            return Response({"message": "User not authorized"}, status=status.HTTP_401_UNAUTHORIZED)
 
         except Rock.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -46,6 +46,22 @@ class RockView(ViewSet):
 
         return Response(serialized.data, status=status.HTTP_201_CREATED)
 
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single item
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            rock = Rock.objects.get(pk=pk)
+            rock.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        except Rock.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class RockTypeSerializer(serializers.ModelSerializer):
     """JSON serializer"""

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -55,7 +55,7 @@ class RockView(ViewSet):
         try:
             rock = Rock.objects.get(pk=pk)
 
-            if rock.user == request.auth.user:
+            if rock.user.id == request.auth.user.id:
                 rock.delete()
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
             

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -59,7 +59,7 @@ class RockView(ViewSet):
                 rock.delete()
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
             
-            return Response({"message": "User not authorized"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"message": "You are not the Owner of that Rock"}, status=status.HTTP_403_FORBIDDEN)
 
         except Rock.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Purpose
To allow Users to delete Rocks that they created

### Files Changed
- Added DELETE endpoint for Rocks in `rock_view.py`

### To Test
Fetch, setup, create or recreate database, then run and confirm the following
- DELETE endpoint `/rocks/{id}` removes the appropriate Rock, if request is sent by the User that created it
- DELETE endpoint `/rocks/{id}` requests for a Rock created by a different User returns 403 FORBIDDEN